### PR TITLE
Feature/adjust link

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -30,12 +30,12 @@
                 </div>
 
                 <div class="form-group">
-                    {!! Form::label('birthday', 'Birthday') !!}
+                    {!! Form::label('birthday', '誕生日') !!}
                     {!! Form::date('birthday', \Carbon\Carbon::now(), ['class' => 'form-control']) !!}
                 </div>
                 
                 <div class="form-group">
-                    {!! Form::label('birthplace', 'Birthplace') !!}
+                    {!! Form::label('birthplace', '出身地') !!}
                         <select name="birthplace" class="form-control">
                         <option value="" selected="selected">選択</option>
                           @foreach(config('pref') as $index=>$name)

--- a/resources/views/entertainers/show.blade.php
+++ b/resources/views/entertainers/show.blade.php
@@ -65,11 +65,13 @@
                         @foreach ($entertainer->perfomers as $value)
                         <tr>
                             <td>{!! link_to_route('perfomers.show', $value->name, ['id' => $value->id]) !!}</td>
+
                             @empty($value->birthday)
                             <td>-</td>
                             @else
                             <td>{!! link_to_route('lists.age2List', $now->diffInYears($value->birthday), ['yearsOld' => $now->diffInYears($value->birthday)]) !!}歳</td>
                             @endempty
+
                             @empty($value->active)
                             <td>-</td>
                             @else
@@ -121,7 +123,7 @@
             <td>{{ $entertainer->encounter }}</td>
         </tr>        
         <tr>
-            <th>コンビ名の由来</th>
+            <th>名前の由来</th>
             <td>{{ $entertainer->named }}</td>
         </tr> 
         <tr>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -89,10 +89,10 @@
 
                                     {{--コンビ名リンク、個人と芸人が同じ場合は表示しない--}}
                                     @if(!empty($value->entertainer[0]->name))
-                                    @if (strcmp($value->entertainer[0]->name, $value->name) == 0 )
-                                    @else
-                                        </br><font size="small">{!! link_to_route('entertainers.show', $value->entertainer[0]->name, $value->entertainer[0]->id) !!}</font>
-                                    @endif
+                                        @if (strcmp($value->entertainer[0]->name, $value->name) == 0 )
+                                        @else
+                                            </br><font size="small">{!! link_to_route('entertainers.show', $value->entertainer[0]->name, $value->entertainer[0]->id) !!}</font>
+                                        @endif
                                     @endif
                                 </td>
                                 

--- a/resources/views/lists/historyList.blade.php
+++ b/resources/views/lists/historyList.blade.php
@@ -6,6 +6,7 @@
 
 <center><h1 class="mt-5 pb-2">芸歴 {{ $year }} 年目</h1></center>
 
+
 @include('commons.tab_combi')
 <br><center>{!! link_to_route('lists.historyList', '<<1年後輩', ['year' => $minus],['class' => 'btn btn-outline-success']) !!}　{!! link_to_route('lists.historyList', '1年先輩>>', ['year' => $plus],['class' => 'btn btn-outline-success']) !!}</center>
 

--- a/resources/views/perfomers/show.blade.php
+++ b/resources/views/perfomers/show.blade.php
@@ -36,7 +36,13 @@
                 @foreach ($perfomer->entertainer as $value)
                 <tr>
                     <td nowrap>{!! link_to_route('entertainers.show', $value->name, ['id' => $value->id]) !!}</td>
-                    <td nowrap>{{$now->diffInYears($value->active)}}年</td>
+
+                    @empty($value->active)
+                    <td>-</td>
+                    @else
+                    <td>{!! link_to_route('lists.historyList', $now->diffInYears($value->active), ['year' => $now->diffInYears($value->active)]) !!}年</td>
+                    @endempty
+
                 </tr>
                 @endforeach
             </tbody>
@@ -50,7 +56,7 @@
         </tr>
         <tr>
             <th>誕生日</th>
-            <td>{{!empty($perfomer->birthday) ? $perfomer->birthday->format('Y年m月d日') : '-' }}</td>
+            <td>{{!empty($perfomer->birthday) ? $perfomer->birthday->format('Y年m月d日') : '-' }}　{{ link_to_route('lists.age2List', $now->diffInYears($perfomer->birthday), ['yearsOld' => $now->diffInYears($perfomer->birthday)]) }}歳</td>
         </tr>
         <tr>
             <th>没年月日</th>
@@ -61,7 +67,7 @@
             <td>{{ $perfomer->birthplace }}</td>
         </tr>
         <tr>
-            <th>血液型</th>
+            <th>血液型</th歳
             <td>{{ $perfomer->bloodtype }}</td>
         </tr>        
         <tr>


### PR DESCRIPTION
　個人：生年月日に現在の年齢表示、からのリンク
　個人：芸歴からリンク
　個人：コンビ名は古い順に表示？新しい順？
　　　　誕生日の1件表示の時に最新のコンビ名を表示
　個人：解散済み表示
　個人・芸人：関連項目表示

　個人：芸人の芸歴ゼロの表示
　芸人：個人の芸歴ゼロの表示
　芸歴一覧
　先輩後輩でなく、○年目、○年目とする

　芸人
　コンビ名の由来→名前の由来

　年齢：芸歴リンク
　トップ：管理者用タグ、同じ名前削除

　一括アップロード：フラッシュメッセージ

