### PR TITLE
サイトのデザイン使いやすさ調整

### DIFF
--- a/app/Http/Controllers/EntertainersController.php
+++ b/app/Http/Controllers/EntertainersController.php
@@ -46,7 +46,10 @@ class EntertainersController extends Controller
         */
 
 
-        //本日・明日の誕生日を表示
+        /*
+        本日・明日の誕生日を表示
+        */
+        
         $today = Carbon::now();
         $tomorrow = Carbon::tomorrow();
         $birthday = array();
@@ -55,6 +58,8 @@ class EntertainersController extends Controller
         
         $perfomers = Perfomer::with(['entertainer'])->where('deth', '=', NULL)->orderBy('birthday', 'asc')->get();
 
+
+        //本日誕生日を取得
         foreach($perfomers as $value){
             $day = $value->birthday;
             if($day !== NULL){
@@ -63,7 +68,8 @@ class EntertainersController extends Controller
                 }
             }
         }    
-        
+
+        //明日誕生日を取得        
         foreach($perfomers as $value){
             $day = $value->birthday;
             if($day !== NULL){

--- a/app/Http/Controllers/EntertainersController.php
+++ b/app/Http/Controllers/EntertainersController.php
@@ -512,27 +512,13 @@ class EntertainersController extends Controller
            
         $search = $request->search;           
 
-        //getパラメータから「解散済みを含めるか？」のチェックを受け取る        
-        // $disband = request('disband');
-
-        // if($disband == '1'){
-        //     $search_1 = Entertainer::where('name', 'like', "%$search%")->get();
-        //     $search_2 = Perfomer::where('name', 'like', "%$search%")->get();           
-        // }
-        // else{
-        //     $search_1 = Entertainer::where('activeend', NULL)->where('name', 'like', "%$search%")->get();
-        //     $search_2 = Perfomer::where('activeend', NULL)->where('name', 'like', "%$search%")->get();           
-        // }
-
-           
-           
-          $search_1 = Entertainer::where('name', 'like', "%$search%")->get();
-          $search_2 = Perfomer::where('name', 'like', "%$search%")->get();           
+          $entertainer = Entertainer::where('name', 'like', "%$search%")->get();
+          $perfomer = Perfomer::where('name', 'like', "%$search%")->get();           
         
             // 一覧ビューで表示
             return view('searchbox', [
-            'search_1' => $search_1,
-            'search_2' => $search_2,            
+            'entertainer' => $entertainer,
+            'perfomer' => $perfomer,            
             'now' => new \Carbon\Carbon(),
         ]);
             

--- a/app/Http/Controllers/ListsController.php
+++ b/app/Http/Controllers/ListsController.php
@@ -449,11 +449,12 @@ class ListsController extends Controller
         
 
         for($i=1950; $i<=2038; $i++){
+
             $years[] = $i;
             $counts[] = Award::where('year','=', $i)->count(); 
         }
 
-        $m1_count = Award::where('award','like', '%'.'M-1'.'%')->count();       
+        $m1_count = Award::where('award','like', '%'.'M-1グランプリ'.'%')->count();       
         $king_count = Award::where('award','like', '%'.'キングオブコント'.'%')->count();
         $kamigata_count = Award::where('award','like', '%'.'上方漫才大賞'.'%')->count();        
         

--- a/resources/views/entertainers/show.blade.php
+++ b/resources/views/entertainers/show.blade.php
@@ -38,7 +38,7 @@
     <table class="table table-bordered">
         <tr>
             <th>芸人</th>
-            <td>{{ $entertainer->name }}</td>
+            <td>{{ $entertainer->name }}{{!empty($entertainer->activeend) ? '（解散済）' : '' }}</td>
         </tr>
         <tr>
             <th>別名</th>
@@ -64,7 +64,7 @@
                     <tbody>
                         @foreach ($entertainer->perfomers as $value)
                         <tr>
-                            <td>{!! link_to_route('perfomers.show', $value->name, ['id' => $value->id]) !!}</td>
+                            <td>{!! link_to_route('perfomers.show', $value->name, ['id' => $value->id]) !!}{{!empty($value->deth) ? '（故人）' : '' }}</td>
 
                             @empty($value->birthday)
                             <td>-</td>
@@ -99,8 +99,8 @@
             @empty($entertainer->activeend)
             <td></td>
             @else
-            <td>{{ $entertainer->activeend->format('Y年')}}　
-                （活動{{$now->diffInYears($entertainer->active)-$now->diffInYears($entertainer->activeend)}}年）</td>   
+            <td>{{ $entertainer->activeend->format('Y年')}}　（活動芸歴{{link_to_route('lists.historyList', $entertainer->active->diffInYears($entertainer->activeend), ['year' => $entertainer->active->diffInYears($entertainer->activeend)])}}年）
+            </td>   
             </td>
             @endempty
             

--- a/resources/views/lists/award.blade.php
+++ b/resources/views/lists/award.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
 </br>
-                                M-1グランプリ{!! link_to_route('lists.awardGp', $m1_count ,['gp' => 'M-1'] ) !!}組｜
+                                M-1グランプリ{!! link_to_route('lists.awardGp', $m1_count ,['gp' => 'M-1グランプリ'] ) !!}組｜
                                 キングオブコント{!! link_to_route('lists.awardGp', $king_count ,['gp' => 'キングオブコント'] ) !!}組｜
                                 上方漫才大賞{!! link_to_route('lists.awardGp', $kamigata_count ,['gp' => '上方漫才大賞'] ) !!}組
 

--- a/resources/views/perfomers/show.blade.php
+++ b/resources/views/perfomers/show.blade.php
@@ -9,7 +9,7 @@
         </div>
     </div>
 
-    <table class="table table-bordered">
+    <table class="table">
         <tr>
             <th>名前</th>
             <td>{{ $perfomer->name }}</td>
@@ -24,7 +24,7 @@
         @empty($perfomer->entertainer)
         <td></td>
         @else
-        <table class="table table-striped">
+        <table class="table table-bordered">
             <thead>
                 <tr>
                     <th>芸人</th>

--- a/resources/views/perfomers/show.blade.php
+++ b/resources/views/perfomers/show.blade.php
@@ -4,15 +4,15 @@
 
     <div class="container">
         <div class="row">
-        <div class="col-lg-3"><h1 class="mt-3 pb-0">芸歴{{$now->diffInYears($perfomer->active)}}年目：</h1></div> 
-        <div class="col-lg-9"><h1 class="mt-3 pb-2"><strong>{{ $perfomer->name }}</strong></h1></div>
+            <div class="col-lg-4"><h1 class="mt-3 pb-0">芸歴{{$now->diffInYears($perfomer->active)}}年目：</h1></div> 
+            <div class="col-lg-8"><h1 class="mt-3 pb-2"><strong>{{ $perfomer->name }}</strong></h1></div>
         </div>
     </div>
 
     <table class="table">
         <tr>
             <th>名前</th>
-            <td>{{ $perfomer->name }}</td>
+            <td>{{ $perfomer->name }}{{!empty($perfomer->deth) ? '（故人）' : '' }}</td>
         </tr>
         <tr>
             <th>本名</th>
@@ -25,27 +25,38 @@
         <td></td>
         @else
         <table class="table table-bordered">
+            {{--
             <thead>
                 <tr>
                     <th>芸人</th>
                     <th>芸歴</th>
                 </tr>
             </thead>
-            
+            --}}
             <tbody>
                 @foreach ($perfomer->entertainer as $value)
-                <tr>
-                    <td nowrap>{!! link_to_route('entertainers.show', $value->name, ['id' => $value->id]) !!}</td>
-
-                    @empty($value->active)
-                    <td>-</td>
-                    @else
-                    <td>{!! link_to_route('lists.historyList', $now->diffInYears($value->active), ['year' => $now->diffInYears($value->active)]) !!}年</td>
+                    @empty($value->activeend)
+                    <tr>
+                        <td nowrap>{!! link_to_route('entertainers.show', $value->name, ['id' => $value->id]) !!}</td>
+                        @empty($value->active)
+                        <td>-</td>
+                        @else
+                        <td>芸歴{!! link_to_route('lists.historyList', $now->diffInYears($value->active), ['year' => $now->diffInYears($value->active)]) !!}年</td>
+                        @endempty
+                    </tr>
+                    @else                
+                    <tr>
+                        <td nowrap>{!! link_to_route('entertainers.show', $value->name, ['id' => $value->id]) !!}（解散済）</td>
+                        @empty($value->active)
+                        <td>-</td>
+                        @else
+                        <td>活動{{link_to_route('lists.historyList', $value->active->diffInYears($value->activeend), ['year' => $value->active->diffInYears($value->activeend)])}}年</td>
+                        @endempty
+                    </tr>
                     @endempty
-
-                </tr>
                 @endforeach
             </tbody>
+            
         </table>
         @endempty
         </td>
@@ -56,18 +67,32 @@
         </tr>
         <tr>
             <th>誕生日</th>
-            <td>{{!empty($perfomer->birthday) ? $perfomer->birthday->format('Y年m月d日') : '-' }}　{{ link_to_route('lists.age2List', $now->diffInYears($perfomer->birthday), ['yearsOld' => $now->diffInYears($perfomer->birthday)]) }}歳</td>
+            <td>{{!empty($perfomer->birthday) ? $perfomer->birthday->format('Y年m月d日') : '-' }}　
+
+            {{--享年表示--}}
+                @empty($perfomer->deth)
+                    {{ link_to_route('lists.age2List', $now->diffInYears($perfomer->birthday), ['yearsOld' => $now->diffInYears($perfomer->birthday)]) }}歳</td>
+                @else
+                    （{{ link_to_route('lists.age2List', $now->diffInYears($perfomer->birthday), ['yearsOld' => $now->diffInYears($perfomer->birthday)]) }}歳）</td>
+                @endempty
         </tr>
         <tr>
             <th>没年月日</th>
-            <td>{{!empty($perfomer->deth) ? $perfomer->deth->format('Y年m月d日') : '-' }}</td>
+            <td>{{!empty($perfomer->deth) ? $perfomer->deth->format('Y年m月d日') : '-' }}
+
+            {{--享年表示--}}
+                @empty($perfomer->deth)
+                    </td>
+                @else
+                    　享年{{link_to_route('lists.age2List', $perfomer->birthday->diffInYears($perfomer->deth), ['yearsOld' => $perfomer->birthday->diffInYears($perfomer->deth)])}}歳</td>
+                @endempty
         </tr>
         <tr>
             <th>出身地</th>
             <td>{{ $perfomer->birthplace }}</td>
         </tr>
         <tr>
-            <th>血液型</th歳
+            <th>血液型</th>
             <td>{{ $perfomer->bloodtype }}</td>
         </tr>        
         <tr>
@@ -96,7 +121,7 @@
         </tr>
         <tr>
             <th>活動終了時期</th>
-            <td>{{!empty($perfomer->activeend) ? $perfomer->activeend : '-' }}</td>
+            <td>{{!empty($perfomer->activeend) ? $perfomer->activeend->format('Y年') : '-' }}</td>
         </tr>
         <tr>
             <th>配偶者</th>

--- a/resources/views/searchbox.blade.php
+++ b/resources/views/searchbox.blade.php
@@ -21,7 +21,7 @@
             <tbody>
                 
                 {{--芸人の検索結果--}}
-                @foreach ($search_1 as $value)
+                @foreach ($entertainer as $value)
                     @if($value->activeend == NULL) {{--解散済みの場合はグレー文字--}}
                     <tr>
                         <td nowrap>{!! link_to_route('entertainers.show', $value->name, ['id' => $value->id]) !!}</td>
@@ -37,8 +37,8 @@
                 @endforeach
                 
                 {{--個人の検索結果--}}                
-                @foreach ($search_2 as $value)
-                    @if($value->activeend == NULL) {{--解散済みの場合はグレー文字--}}
+                @foreach ($perfomer as $value)
+                    @if($value->deth == NULL) {{--故人の場合はグレー文字--}}
                     <tr>
                         <td nowrap>{!! link_to_route('perfomers.show', $value->name, ['id' => $value->id]) !!}（個人）</td>
                         <td>{{$now->diffInYears($value->active)}}年</td>
@@ -46,7 +46,7 @@
                     @else
     
                     <tr class="text-secondary">
-                        <td nowrap>{!! link_to_route('perfomers.show', $value->name, ['id' => $value->id]) !!}（解散済）</td>
+                        <td nowrap>{!! link_to_route('perfomers.show', $value->name, ['id' => $value->id]) !!}（故人）</td>
                         <td>{{$now->diffInYears($value->active)}}年</td>
                     </tr>
                     @endif


### PR DESCRIPTION
・芸人と個人で表示形式を変える、テーブルのボーダー有り無し
・個人：コンビ名は古い順に表示？新しい順？
　誕生日の1件表示の時に最新のコンビ名を表示
・個人：解散済み表示

・受賞年は新しい順へ変更
・受賞年GPは表示を見直す、大会名に２つ表示される

・故人表示
